### PR TITLE
kernel: Use newest clang for kernel build by default

### DIFF
--- a/build/tasks/kernel.mk
+++ b/build/tasks/kernel.mk
@@ -222,6 +222,9 @@ PATH_OVERRIDE := PATH=$(KERNEL_BUILD_OUT_PREFIX)$(HOST_OUT_EXECUTABLES):$$PATH
 ifeq ($(TARGET_KERNEL_CLANG_COMPILE),true)
     ifneq ($(TARGET_KERNEL_CLANG_VERSION),)
         KERNEL_CLANG_VERSION := clang-$(TARGET_KERNEL_CLANG_VERSION)
+    else ifeq ($(TARGET_KERNEL_USE_LATEST_CLANG), true)
+        # Use dedicated path for latest clang
+        KERNEL_CLANG_VERSION := clang-latest
     else
         # Use the default version of clang if TARGET_KERNEL_CLANG_VERSION hasn't been set by the device config
         KERNEL_CLANG_VERSION := $(LLVM_PREBUILTS_VERSION)


### PR DESCRIPTION
By every clang update everyone has had to update clang version in BoardConfig.
Now these flags can be removed as latest clang will be used by default.

Signed-off-by: xNombre <kartapolska@gmail.com>
Signed-off-by: agustkid <agustkid@gmail.com>