### PR TITLE
config/bootanimation: Use `strip` instead of `sed` to filter space

### DIFF
--- a/config/bootanimation.mk
+++ b/config/bootanimation.mk
@@ -21,10 +21,10 @@ endif
 
 # We don't know if the maintainer added space after definition in tree.
 # (E.g. "TARGET_BOOT_ANIMATION_RES := 720 # Random thing)
-# This causes COPY_FILES to malfunction, so delete everything after
-# first space out. There shouldn't be a space before the actual value
-# anyway, Rest In Pepperoni if there is. xD
-TARGET_BOOT_ANIMATION_RES := $(shell echo $(TARGET_BOOT_ANIMATION_RES) | sed -e 's/ .*//')
+# This causes COPY_FILES to malfunction, so trim it. Everything after
+# pound sign is already filtered out by build system so nothing should
+# go wrong.
+TARGET_BOOT_ANIMATION_RES := $(strip $(TARGET_BOOT_ANIMATION_RES))
 
 PRODUCT_COPY_FILES += \
     vendor/lineage/prebuilt/common/bootanimation/bootanimation-$(TARGET_BOOT_ANIMATION_RES).zip:$(TARGET_COPY_OUT_SYSTEM)/media/bootanimation.zip


### PR DESCRIPTION
* This will remove whitespaces before and after the value we need.

Signed-off-by: Beru Shinsetsu <windowz414@1337.lgbt>